### PR TITLE
Restore full dashboard script

### DIFF
--- a/cme_dashboard_v1.py
+++ b/cme_dashboard_v1.py
@@ -1,0 +1,207 @@
+# Real-Time NG Edge Dashboard: Unified Implementation
+# Combines: Level 2 data ingestion, feature extraction, geometry (Fibonacci), rhythm (vibration/frequency), confidence scoring, trend phase, edge scoring, trend age, exhaustion alerts.
+
+import asyncio
+import os
+import math
+from collections import deque, Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Deque, List, Literal, Optional
+
+from dotenv import load_dotenv
+from ib_insync import IB, Contract
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+
+load_dotenv()
+
+# --------------------------- Settings --------------------------- #
+TWS_HOST = os.getenv("TWS_HOST", "127.0.0.1")
+TWS_PORT = int(os.getenv("TWS_PORT", "7497"))
+TWS_CLIENT_ID = int(os.getenv("TWS_CLIENT_ID", "101"))
+DEPTH_LEVELS = 5
+ROLL_WINDOW = 120
+
+Side = Literal["bid", "ask"]
+
+# ------------------------- Data Classes ------------------------- #
+@dataclass
+class L2Level:
+    side: Side
+    position: int
+    price: float
+    size: float
+    mm_id: str
+    update_type: int
+
+@dataclass
+class L2Snapshot:
+    bids: List[L2Level]
+    asks: List[L2Level]
+    last_price: float
+    ts_exchange: datetime
+    ts_local: datetime
+
+@dataclass
+class FeatureVector:
+    ts: datetime
+    mid: float
+    vwap: float
+    imbalance: float
+    wall_size: float
+    delta: float
+    fib_prox: float
+    energy: float
+    vibration: float
+    resonance: float
+    trend_age: int
+    exhaustion: bool
+    edge_score: float
+
+# --------------------------- L2 Ingestor --------------------------- #
+class L2Ingestor:
+    def __init__(self, queue: asyncio.Queue):
+        self.ib = IB()
+        self.queue = queue
+        self._snapshot: dict[str, list[L2Level]] = {"bid": [], "ask": []}
+        self._last_price: float = 0.0
+
+    async def start(self):
+        contract = Contract(symbol="NG", secType="FUT", exchange="NYMEX", currency="USD")
+        await self.ib.connectAsync(TWS_HOST, TWS_PORT, clientId=TWS_CLIENT_ID)
+        await self.ib.qualifyContractsAsync(contract)
+        self.ib.reqMktDepth(contract, numRows=DEPTH_LEVELS, isSmartDepth=False)
+        self.ib.pendingTickersEvent += self._on_tick
+        self.ib.updateMktDepthEvent += self._on_depth
+
+    def _on_tick(self, tickers):
+        for t in tickers:
+            if t.last:
+                self._last_price = t.last
+
+    def _on_depth(self, req_id, pos, op, side, price, size, mm_id):
+        s = "bid" if side == 1 else "ask"
+        lvl = L2Level(s, pos, price, size, mm_id, op)
+        book_side = self._snapshot[s]
+        while len(book_side) <= pos:
+            book_side.append(lvl)
+        book_side[pos] = lvl
+        if len(self._snapshot["bid"]) and len(self._snapshot["ask"]):
+            snap = L2Snapshot(
+                bids=self._snapshot["bid"][:DEPTH_LEVELS],
+                asks=self._snapshot["ask"][:DEPTH_LEVELS],
+                last_price=self._last_price,
+                ts_exchange=datetime.now(timezone.utc),
+                ts_local=datetime.utcnow().replace(tzinfo=timezone.utc)
+            )
+            asyncio.create_task(self.queue.put(snap))
+
+# ----------------------- Feature Extraction ------------------------ #
+class FeatureEngine:
+    def __init__(self, in_q: asyncio.Queue, out_q: asyncio.Queue):
+        self.in_q, self.out_q = in_q, out_q
+        self.snapshots: Deque[L2Snapshot] = deque(maxlen=ROLL_WINDOW)
+        self.fib_levels = []
+        self.phase = "Initializing"
+        self.trend_start_ts: Optional[datetime] = None
+
+    async def run(self):
+        while True:
+            snap = await self.in_q.get()
+            self.snapshots.append(snap)
+            if len(self.snapshots) < 10:
+                continue
+            fv = self._compute(snap)
+            await self.out_q.put(fv)
+
+    def _compute(self, snap: L2Snapshot) -> FeatureVector:
+        mid = (snap.bids[0].price + snap.asks[0].price) / 2
+        vwap, sizes = 0.0, [sum(l.size for l in s.bids + s.asks) for s in self.snapshots]
+        prices = [s.last_price for s in self.snapshots]
+        vwap = sum(p * q for p, q in zip(prices, sizes)) / sum(sizes)
+
+        imbalance = sum(l.size for l in snap.bids) - sum(l.size for l in snap.asks)
+        wall = max([l.size for l in snap.bids + snap.asks], default=0)
+        delta = mid - vwap
+
+        hi, lo = max(prices), min(prices)
+        self.fib_levels = [hi - r * (hi - lo) for r in (0.382, 0.5, 0.618)]
+        fib_prox = min(abs(mid - f) for f in self.fib_levels)
+
+        energy = mid - (self.snapshots[-10].last_price)
+        diffs = [prices[i+1] - prices[i] for i in range(len(prices)-1)]
+        vibration = float(pd.Series(diffs).std())
+        bin_counts = Counter(round(p, 2) for p in prices)
+        resonance = max(bin_counts.values()) / len(prices)
+
+        now = snap.ts_local
+        if self.phase in ["TrendingUp", "TrendingDown"]:
+            if not self.trend_start_ts:
+                self.trend_start_ts = now
+            trend_age = int((now - self.trend_start_ts).total_seconds())
+        else:
+            self.trend_start_ts = None
+            trend_age = 0
+
+        exhaustion = energy < 0.05 and vibration < 0.03 and fib_prox < 0.02
+        edge_score = 0.3 * min(100, max(0, imbalance)) + 0.2 * energy + 0.2 * (1 - fib_prox) + 0.3 * vibration
+
+        return FeatureVector(
+            ts=now, mid=mid, vwap=vwap, imbalance=imbalance, wall_size=wall,
+            delta=delta, fib_prox=fib_prox, energy=energy, vibration=vibration,
+            resonance=resonance, trend_age=trend_age, exhaustion=exhaustion,
+            edge_score=round(edge_score, 2)
+        )
+
+# --------------------------- Dashboard --------------------------- #
+class Dashboard:
+    def __init__(self, q: asyncio.Queue):
+        self.q = q
+        self.last: Optional[FeatureVector] = None
+
+    async def run(self):
+        async with Live(self._render(), refresh_per_second=1) as live:
+            while True:
+                while not self.q.empty():
+                    self.last = await self.q.get()
+                    live.update(self._render(), refresh=True)
+                await asyncio.sleep(1)
+
+    def _render(self) -> Panel:
+        table = Table(title="NG Edge Forecast", expand=True)
+        table.add_column("Metric")
+        table.add_column("Value", justify="right")
+        if self.last:
+            f = self.last
+            table.add_row("Time", f.ts.strftime("%H:%M:%S"))
+            table.add_row("Mid", f"{f.mid:.3f}")
+            table.add_row("VWAP", f"{f.vwap:.3f}")
+            table.add_row("Imbalance", f"{f.imbalance:.1f}")
+            table.add_row("Wall Size", f"{f.wall_size:.1f}")
+            table.add_row("Delta", f"{f.delta:.3f}")
+            table.add_row("Fib Prox", f"{f.fib_prox:.4f}")
+            table.add_row("Energy", f"{f.energy:+.4f}")
+            table.add_row("Vibration", f"{f.vibration:.4f}")
+            table.add_row("Resonance", f"{f.resonance:.2f}")
+            table.add_row("Trend Age (s)", str(f.trend_age))
+            table.add_row("Exhaustion", "Yes" if f.exhaustion else "No")
+            table.add_row("Edge Score", f"{f.edge_score:.2f}")
+        return Panel(table, border_style="cyan")
+
+# --------------------------- Main --------------------------- #
+async def main():
+    q_raw = asyncio.Queue()
+    q_feat = asyncio.Queue()
+
+    ingestor = L2Ingestor(queue=q_raw)
+    feats = FeatureEngine(q_raw, q_feat)
+    dash = Dashboard(q_feat)
+
+    await ingestor.start()
+    await asyncio.gather(feats.run(), dash.run())
+
+if __name__ == "__main__":
+    import pandas as pd
+    asyncio.run(main())

--- a/live_dash.py
+++ b/live_dash.py
@@ -1,0 +1,204 @@
+"""Minimal live NG futures dashboard using rich and ib-insync."""
+
+import asyncio
+import os
+import signal
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict
+
+import pandas as pd
+from dotenv import load_dotenv
+from ib_insync import IB, Contract, util
+from rich.live import Live
+from rich.table import Table
+
+# ----------------------------------------------------------------------
+# Load environment settings
+# ----------------------------------------------------------------------
+load_dotenv()
+TWS_HOST = os.getenv("TWS_HOST", "127.0.0.1")
+TWS_PORT = int(os.getenv("TWS_PORT", "7497"))
+TWS_CLIENT_ID = int(os.getenv("TWS_CLIENT_ID", "123"))
+BAR_SIZE = "5 secs"          # use "1 min" or larger if you prefer
+HIST_DURATION = "2 D"         # bootstrap recent bars for indicators
+
+
+@dataclass
+class Bar:
+    ts: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: int
+
+
+class IBFeed:
+    """Subscribe to real-time bars and maintain a rolling DataFrame."""
+
+    def __init__(self, queue: asyncio.Queue):
+        self.q = queue
+        self.ib = IB()
+        self.df = pd.DataFrame()
+
+    def create_mes_contract(self) -> Contract:
+        contract = Contract()
+        contract.symbol = "NG"
+        contract.secType = "FUT"
+        contract.exchange = "NYMEX"
+        contract.currency = "USD"
+        contract.lastTradeDateOrContractMonth = "20250626"
+        contract.localSymbol = "NGN25"
+        contract.multiplier = "10000"
+        return contract
+
+    async def start(self):
+        await self.ib.connectAsync(TWS_HOST, TWS_PORT, clientId=TWS_CLIENT_ID)
+        cont = self.create_mes_contract()
+        await self.ib.qualifyContractsAsync(cont)
+
+        # recent history for indicator warm-up
+        self.df = util.df(
+            self.ib.reqHistoricalData(
+                cont,
+                endDateTime="",
+                durationStr=HIST_DURATION,
+                barSizeSetting=BAR_SIZE,
+                whatToShow="TRADES",
+                useRTH=False,
+                formatDate=1,
+            )
+        )
+        self.df.set_index("date", inplace=True)
+
+        # subscribe to live bars
+        self.ib.reqRealTimeBars(cont, 5, "TRADES", False)
+        self.ib.realTimeBarEvent += self._on_bar
+
+        while True:
+            await asyncio.sleep(1)
+
+    def _on_bar(self, bar):
+        ts = pd.Timestamp(bar.time, unit="s", tz="UTC")
+        self.df.loc[ts] = [bar.open, bar.high, bar.low, bar.close, bar.volume]
+        self.df = self.df.tail(1000)
+        asyncio.create_task(self.q.put(ts))
+
+
+class Indicators:
+    """Compute basic indicators on the latest bars."""
+
+    def __init__(self, df: pd.DataFrame):
+        self.df = df
+
+    def compute(self) -> Dict[str, float]:
+        df = self.df.tail(200).copy()
+        df["MA_20"] = df["close"].rolling(20).mean()
+        df["MA_50"] = df["close"].rolling(50).mean()
+        df["rsi_14"] = self._rsi(df["close"], 14)
+        df["atr_14"] = self._atr(df, 14)
+        df["macd"] = self._macd(df["close"])
+        last = df.iloc[-1]
+        piv = self._pivots(last.high, last.low, last.close)
+        return {
+            "price": last.close,
+            "ma20": last.MA_20,
+            "ma50": last.MA_50,
+            "rsi": last.rsi_14,
+            "macd": last.macd,
+            "atr": last.atr_14,
+            "r1": piv[1],
+            "s1": piv[4],
+        }
+
+    @staticmethod
+    def _rsi(series: pd.Series, period: int) -> pd.Series:
+        delta = series.diff()
+        up = delta.clip(lower=0)
+        down = -delta.clip(upper=0)
+        ma_up = up.ewm(com=period - 1, adjust=False).mean()
+        ma_down = down.ewm(com=period - 1, adjust=False).mean()
+        rs = ma_up / ma_down
+        return 100 - (100 / (1 + rs))
+
+    @staticmethod
+    def _atr(df: pd.DataFrame, period: int) -> pd.Series:
+        prev_close = df["close"].shift(1)
+        tr1 = df["high"] - df["low"]
+        tr2 = (df["high"] - prev_close).abs()
+        tr3 = (df["low"] - prev_close).abs()
+        true_range = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
+        return true_range.rolling(period).mean()
+
+    @staticmethod
+    def _macd(series: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9) -> pd.Series:
+        ema_fast = series.ewm(span=fast, adjust=False).mean()
+        ema_slow = series.ewm(span=slow, adjust=False).mean()
+        macd_line = ema_fast - ema_slow
+        signal_line = macd_line.ewm(span=signal, adjust=False).mean()
+        return macd_line - signal_line
+
+    @staticmethod
+    def _pivots(high: float, low: float, close: float):
+        pp = (high + low + close) / 3
+        r1 = 2 * pp - low
+        r2 = pp + (high - low)
+        r3 = high + 2 * (pp - low)
+        s1 = 2 * pp - high
+        s2 = pp - (high - low)
+        s3 = low - 2 * (high - pp)
+        return pp, r1, r2, r3, s1, s2, s3
+
+
+class Dashboard:
+    def __init__(self, feed: IBFeed, queue: asyncio.Queue):
+        self.feed = feed
+        self.q = queue
+        self.metrics = {}
+
+    async def run(self):
+        async with Live(self._render(), refresh_per_second=4) as live:
+            while True:
+                await self.q.get()
+                self.metrics = Indicators(self.feed.df).compute()
+                live.update(self._render(), refresh=True)
+
+    def _render(self) -> Table:
+        table = Table(title="NG FUT LIVE DASH", expand=True)
+        table.add_column("Metric")
+        table.add_column("Value", justify="right")
+        if self.metrics:
+            table.add_row("UTC", datetime.utcnow().strftime("%H:%M:%S"))
+            table.add_row("Last Px", f"{self.metrics['price']:.3f}")
+            table.add_row("MA 20", f"{self.metrics['ma20']:.3f}")
+            table.add_row("MA 50", f"{self.metrics['ma50']:.3f}")
+            table.add_row("RSI 14", f"{self.metrics['rsi']:.1f}")
+            table.add_row("MACD", f"{self.metrics['macd']:.3f}")
+            table.add_row("ATR 14", f"{self.metrics['atr']:.3f}")
+            table.add_row("Pivot R1", f"{self.metrics['r1']:.3f}")
+            table.add_row("Pivot S1", f"{self.metrics['s1']:.3f}")
+        return table
+
+
+async def shutdown(feed: IBFeed):
+    print("Disconnecting …")
+    feed.ib.disconnect()
+    await asyncio.sleep(0.2)
+    raise SystemExit(0)
+
+
+async def main():
+    q = asyncio.Queue()
+    feed = IBFeed(q)
+    dash = Dashboard(feed, q)
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, lambda: asyncio.create_task(shutdown(feed)))
+
+    await asyncio.gather(feed.start(), dash.run())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ng_trend_dashboard.py
+++ b/ng_trend_dashboard.py
@@ -1,0 +1,528 @@
+"""
+Real-Time NG Trend Confidence Dashboard (single-file version)
+Dependencies: ib-insync, rich, aiosqlite, python-dotenv
+"""
+
+import asyncio
+import json
+import math
+import os
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Deque, List, Literal
+
+from dotenv import load_dotenv
+from ib_insync import IB, Contract, util
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+import aiosqlite
+
+load_dotenv()
+
+# ----------------------------- Configuration ----------------------------- #
+
+@dataclass(frozen=True)
+class Settings:
+    tws_host: str = os.getenv("TWS_HOST", "127.0.0.1")
+    tws_port: int = int(os.getenv("TWS_PORT", "7497"))
+    tws_client_id: int = int(os.getenv("TWS_CLIENT_ID", "42"))
+    depth_levels: int = int(os.getenv("DEPTH_LEVELS", "5"))
+    roll_window_s: int = int(os.getenv("ROLL_WINDOW_S", "120"))
+    conf_tau_s: int = int(os.getenv("CONF_TAU_S", "30"))
+
+settings = Settings()
+
+Side = Literal["bid", "ask"]
+
+
+# ----------------------------- Level 2 Ingestion ----------------------------- #
+
+@dataclass
+class L2Level:
+    side: Side
+    position: int
+    price: float
+    size: float
+    mm_id: str
+    update_type: int
+
+
+@dataclass
+class L2Snapshot:
+    bids: List[L2Level]
+    asks: List[L2Level]
+    last_price: float
+    ts_exchange: datetime
+    ts_local: datetime
+
+
+class L2Ingestor:
+    def __init__(self, contract: Contract, queue: asyncio.Queue):
+        self.ib = IB()
+        self.contract = contract
+        self.queue = queue
+        self.depth_levels = settings.depth_levels
+        self._snapshot: dict[str, list[L2Level]] = {"bid": [], "ask": []}
+
+    async def start(self) -> None:
+        await self.ib.connectAsync(
+            settings.tws_host, settings.tws_port, clientId=settings.tws_client_id
+        )
+        self._register_handlers()
+        self.ib.reqMktDepth(self.contract, numRows=self.depth_levels, isSmartDepth=False)
+
+    def _register_handlers(self) -> None:
+        self.ib.pendingTickersEvent += self._on_tick_price
+        self.ib.updateMktDepthEvent += self._on_depth
+
+    def _on_tick_price(self, tickers):
+        for t in tickers:
+            if t.contract.conId != self.contract.conId:
+                continue
+            self._last_price = t.last
+            break
+
+    def _on_depth(
+        self,
+        req_id: int,
+        position: int,
+        operation: int,
+        side: int,
+        price: float,
+        size: float,
+        mm_id: str,
+    ):
+        side_str: Side = "bid" if side == 1 else "ask"
+        level = L2Level(
+            side=side_str,
+            position=position,
+            price=price,
+            size=size,
+            mm_id=mm_id,
+            update_type=operation,
+        )
+        book_side = self._snapshot[side_str]
+        while len(book_side) <= position:
+            book_side.append(level)
+        book_side[position] = level
+        if len(self._snapshot["bid"]) and len(self._snapshot["ask"]):
+            snap = L2Snapshot(
+                bids=self._snapshot["bid"][: self.depth_levels],
+                asks=self._snapshot["ask"][: self.depth_levels],
+                last_price=getattr(self, "_last_price", 0.0),
+                ts_exchange=datetime.now(timezone.utc),
+                ts_local=datetime.utcnow().replace(tzinfo=timezone.utc),
+            )
+            asyncio.create_task(self.queue.put(snap))
+
+
+# ----------------------------- Feature Engineering ----------------------------- #
+
+@dataclass
+class FeatureVector:
+    ts: datetime
+    book_imbalance: float
+    absorption_score: float
+    spoof_flag: bool
+    wall_px: float | None
+    wall_size: float | None
+    vwap_delta: float
+
+
+class FeatureEngine:
+    def __init__(self, in_q: asyncio.Queue, out_q: asyncio.Queue):
+        self.in_q, self.out_q = in_q, out_q
+        self.buffer: Deque[L2Snapshot] = deque(maxlen=settings.roll_window_s)
+
+    async def run(self):
+        while True:
+            snap: L2Snapshot = await self.in_q.get()
+            self.buffer.append(snap)
+            if len(self.buffer) < 2:
+                continue
+            fv = self._compute_features()
+            await self.out_q.put(fv)
+
+    def _compute_features(self) -> FeatureVector:
+        latest = self.buffer[-1]
+        bid_qty = sum(l.size for l in latest.bids)
+        ask_qty = sum(l.size for l in latest.asks)
+        book_imbalance = bid_qty - ask_qty
+        repeat_price = latest.bids[0].price == self.buffer[-2].bids[0].price
+        filled_size = self.buffer[-2].bids[0].size - latest.bids[0].size
+        absorption_score = max(0.0, filled_size) / max(1.0, self.buffer[-2].bids[0].size)
+        spoof_flag = False
+        if len(self.buffer) >= 3:
+            prev2 = self.buffer[-3].bids[0].size
+            prev1 = self.buffer[-2].bids[0].size
+            cur = latest.bids[0].size
+            if prev1 > prev2 * 2 and cur < prev1 / 2:
+                spoof_flag = True
+        wall_px, wall_size = None, None
+        for lvl in latest.bids + latest.asks:
+            if lvl.size > max(bid_qty, ask_qty) * 0.5:
+                wall_px, wall_size = lvl.price, lvl.size
+                break
+        prices = [s.last_price for s in self.buffer]
+        sizes = [sum(l.size for l in s.bids + s.asks) for s in self.buffer]
+        vwap = sum(p * q for p, q in zip(prices, sizes)) / sum(sizes)
+        vwap_delta = latest.last_price - vwap
+        return FeatureVector(
+            ts=latest.ts_local,
+            book_imbalance=book_imbalance,
+            absorption_score=absorption_score,
+            spoof_flag=spoof_flag,
+            wall_px=wall_px,
+            wall_size=wall_size,
+            vwap_delta=vwap_delta,
+        )
+
+
+# ----------------------------- Confidence Engine ----------------------------- #
+
+@dataclass
+class Confidence:
+    ts: datetime
+    score_pct: float
+    decay_pct: float
+    trajectory: str
+
+
+class ConfidenceEngine:
+    def __init__(self, in_q: asyncio.Queue, out_q: asyncio.Queue):
+        self.in_q, self.out_q = in_q, out_q
+        self.prev_score = 50.0
+
+    async def run(self):
+        while True:
+            fv: FeatureVector = await self.in_q.get()
+            new_score = self._calc_score(fv)
+            decay = new_score - self.prev_score
+            traj = "up" if decay > 1 else "down" if decay < -1 else "flat"
+            conf = Confidence(ts=fv.ts, score_pct=new_score, decay_pct=decay, trajectory=traj)
+            self.prev_score = new_score
+            await self.out_q.put(conf)
+
+    def _calc_score(self, fv: FeatureVector) -> float:
+        β1, β2 = 0.0005, 30.0
+        base = β1 * fv.book_imbalance + β2 * fv.absorption_score
+        if fv.spoof_flag:
+            base -= 20.0
+        decay_factor = math.exp(-10 / settings.conf_tau_s)
+        raw = self.prev_score * decay_factor + base
+        return max(0.0, min(100.0, raw))
+
+
+# ----------------------------- Phase Detector ----------------------------- #
+
+Phase = Literal[
+    "TrendingUp",
+    "TrendingDown",
+    "Expanding",
+    "Choppy",
+    "Consolidating",
+    "Reversing",
+]
+
+
+@dataclass
+class PhaseSnapshot:
+    ts: datetime
+    phase: Phase
+    rationale: str
+
+
+class PhaseDetector:
+    def __init__(self, feat_q: asyncio.Queue, conf_q: asyncio.Queue, out_q: asyncio.Queue):
+        self.feat_q, self.conf_q, self.out_q = feat_q, conf_q, out_q
+        self._latest_feat: FeatureVector | None = None
+        self._latest_conf: Confidence | None = None
+
+    async def run(self):
+        while True:
+            done, _ = await asyncio.wait(
+                [self.feat_q.get(), self.conf_q.get()], return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in done:
+                item = task.result()
+                if isinstance(item, FeatureVector):
+                    self._latest_feat = item
+                else:
+                    self._latest_conf = item
+            if self._latest_feat and self._latest_conf:
+                phase = self._classify(self._latest_feat, self._latest_conf)
+                await self.out_q.put(phase)
+
+    def _classify(self, fv: FeatureVector, conf: Confidence) -> PhaseSnapshot:
+        if conf.score_pct >= 65 and fv.vwap_delta > 0:
+            phase = "TrendingUp"
+        elif conf.score_pct >= 65 and fv.vwap_delta < 0:
+            phase = "TrendingDown"
+        elif abs(fv.book_imbalance) < 1 and abs(fv.vwap_delta) < 0.5:
+            phase = "Consolidating"
+        elif conf.decay_pct < -10:
+            phase = "Reversing"
+        else:
+            phase = "Choppy"
+        return PhaseSnapshot(
+            ts=fv.ts,
+            phase=phase,
+            rationale=f"imb={fv.book_imbalance:.0f}, vwapΔ={fv.vwap_delta:.2f}, conf={conf.score_pct:.1f}",
+        )
+
+
+# ----------------------------- Trader Assist ----------------------------- #
+
+@dataclass
+class Advice:
+    ts: datetime
+    bias: str
+    text: str
+
+
+class TraderAssist:
+    def __init__(self, phase_q: asyncio.Queue, conf_q: asyncio.Queue, out_q: asyncio.Queue):
+        self.phase_q, self.conf_q, self.out_q = phase_q, conf_q, out_q
+        self._last_conf: Confidence | None = None
+
+    async def run(self):
+        while True:
+            done, _ = await asyncio.wait(
+                [self.phase_q.get(), self.conf_q.get()], return_when=asyncio.FIRST_COMPLETED
+            )
+            for t in done:
+                item = t.result()
+                if isinstance(item, Confidence):
+                    self._last_conf = item
+                else:
+                    phase = item
+            if self._last_conf and isinstance(item, PhaseSnapshot):
+                advice = self._advise(phase, self._last_conf)
+                await self.out_q.put(advice)
+
+    def _advise(self, phase: PhaseSnapshot, conf: Confidence) -> Advice:
+        if phase.phase.startswith("TrendingUp") and conf.score_pct > 70:
+            bias = "Hold Long"
+        elif phase.phase.startswith("TrendingDown") and conf.score_pct > 70:
+            bias = "Hold Short"
+        elif phase.phase == "Reversing":
+            bias = "Exit / Flip"
+        elif conf.score_pct < 40:
+            bias = "Flat / Wait"
+        else:
+            bias = "Scalp"
+        txt = f"{bias} | {phase.phase} | conf={conf.score_pct:.0f}% ({conf.trajectory})"
+        return Advice(ts=phase.ts, bias=bias, text=txt)
+
+
+# ----------------------------- Async Logger ----------------------------- #
+
+class LoggerDB:
+    DB_PATH = Path("ng_dash.sqlite")
+
+    def __init__(self):
+        self._queue: asyncio.Queue = asyncio.Queue()
+
+    async def writer(self):
+        async with aiosqlite.connect(self.DB_PATH) as db:
+            await self._create_schema(db)
+            while True:
+                item = await self._queue.get()
+                if isinstance(item, L2Snapshot):
+                    await db.execute(
+                        "INSERT OR IGNORE INTO ticks VALUES(?,?,?,?,?)",
+                        (
+                            int(item.ts_local.timestamp()),
+                            item.last_price,
+                            json.dumps([l.__dict__ for l in item.bids]),
+                            json.dumps([l.__dict__ for l in item.asks]),
+                            item.ts_exchange.timestamp(),
+                        ),
+                    )
+                elif isinstance(item, FeatureVector):
+                    await db.execute(
+                        "INSERT OR IGNORE INTO features VALUES(?,?,?,?,?,?,?)",
+                        (
+                            int(item.ts.timestamp()),
+                            item.book_imbalance,
+                            item.absorption_score,
+                            int(item.spoof_flag),
+                            item.wall_px or 0,
+                            item.wall_size or 0,
+                            item.vwap_delta,
+                        ),
+                    )
+                elif isinstance(item, Confidence):
+                    await db.execute(
+                        "INSERT OR IGNORE INTO confidence VALUES(?,?,?,?)",
+                        (
+                            int(item.ts.timestamp()),
+                            item.score_pct,
+                            item.decay_pct,
+                            item.trajectory,
+                        ),
+                    )
+                elif isinstance(item, PhaseSnapshot):
+                    await db.execute(
+                        "INSERT OR IGNORE INTO phases VALUES(?,?,?)",
+                        (
+                            int(item.ts.timestamp()),
+                            item.phase,
+                            item.rationale,
+                        ),
+                    )
+                elif isinstance(item, Advice):
+                    await db.execute(
+                        "INSERT OR IGNORE INTO advice VALUES(?,?,?)",
+                        (int(item.ts.timestamp()), item.bias, item.text),
+                    )
+                await db.commit()
+
+    async def _create_schema(self, db):
+        await db.executescript(
+            """
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE IF NOT EXISTS ticks(
+                ts_epoch INTEGER PRIMARY KEY,
+                last_price REAL,
+                bids_json TEXT,
+                asks_json TEXT,
+                ts_exch REAL
+            );
+            CREATE TABLE IF NOT EXISTS features(
+                ts_epoch INTEGER PRIMARY KEY,
+                book_imb REAL,
+                absorption REAL,
+                spoof INTEGER,
+                wall_px REAL,
+                wall_sz REAL,
+                vwap_delta REAL
+            );
+            CREATE TABLE IF NOT EXISTS confidence(
+                ts_epoch INTEGER PRIMARY KEY,
+                score REAL,
+                decay REAL,
+                traj TEXT
+            );
+            CREATE TABLE IF NOT EXISTS phases(
+                ts_epoch INTEGER PRIMARY KEY,
+                phase TEXT,
+                rationale TEXT
+            );
+            CREATE TABLE IF NOT EXISTS advice(
+                ts_epoch INTEGER PRIMARY KEY,
+                bias TEXT,
+                txt TEXT
+            );
+            """
+        )
+
+    def queue(self) -> asyncio.Queue:
+        return self._queue
+
+
+# ----------------------------- Dashboard ----------------------------- #
+
+class Dashboard:
+    def __init__(self, conf_q: asyncio.Queue, phase_q: asyncio.Queue, advice_q: asyncio.Queue):
+        self.conf_q, self.phase_q, self.advice_q = conf_q, phase_q, advice_q
+        self._latest_conf: Confidence | None = None
+        self._latest_phase: PhaseSnapshot | None = None
+        self._latest_advice: Advice | None = None
+
+    async def run(self):
+        async with Live(self._render(), auto_refresh=False, refresh_per_second=4) as live:
+            while True:
+                await self._gather_updates()
+                live.update(self._render(), refresh=True)
+                await asyncio.sleep(10)
+
+    async def _gather_updates(self):
+        for q in (self.conf_q, self.phase_q, self.advice_q):
+            while not q.empty():
+                item = q.get_nowait()
+                if isinstance(item, Confidence):
+                    self._latest_conf = item
+                elif isinstance(item, PhaseSnapshot):
+                    self._latest_phase = item
+                else:
+                    self._latest_advice = item
+
+    def _render(self) -> Panel:
+        table = Table(title="NG Trend Confidence", expand=True)
+        table.add_column("Metric", justify="left")
+        table.add_column("Value", justify="right")
+
+        ts = datetime.utcnow().strftime("%H:%M:%S")
+        table.add_row("Timestamp (UTC)", ts)
+
+        if self._latest_conf:
+            bar = self._bar(self._latest_conf.score_pct)
+            table.add_row("Confidence", f"{self._latest_conf.score_pct:.1f}% {bar}")
+            table.add_row("Trajectory", self._latest_conf.trajectory)
+
+        if self._latest_phase:
+            table.add_row("Phase", self._latest_phase.phase)
+            table.add_row("Rationale", self._latest_phase.rationale)
+
+        if self._latest_advice:
+            table.add_row("Advice", self._latest_advice.text)
+
+        return Panel(table, border_style="cyan")
+
+    @staticmethod
+    def _bar(pct: float, length: int = 20) -> str:
+        filled = int(pct / 100 * length)
+        return "[" + "█" * filled + "." * (length - filled) + "]"
+
+
+def create_mes_contract() -> Contract:
+    contract = Contract()
+    contract.symbol = "NG"
+    contract.secType = "FUT"
+    contract.exchange = "NYMEX"
+    contract.currency = "USD"
+    contract.lastTradeDateOrContractMonth = "20250626"
+    contract.localSymbol = "NGN25"
+    contract.multiplier = "10000"
+    return contract
+
+
+# ----------------------------- Main ----------------------------- #
+
+async def main():
+    q_snap = asyncio.Queue(maxsize=1000)
+    q_feat = asyncio.Queue(maxsize=1000)
+    q_conf = asyncio.Queue(maxsize=1000)
+    q_phase = asyncio.Queue(maxsize=1000)
+    q_adv = asyncio.Queue(maxsize=1000)
+
+    logger = LoggerDB()
+    asyncio.create_task(logger.writer())
+
+    ng_contract = create_mes_contract()
+
+    ingestor = L2Ingestor(contract=ng_contract, queue=q_snap)
+    feat_eng = FeatureEngine(q_snap, q_feat)
+    conf_eng = ConfidenceEngine(q_feat, q_conf)
+    phase_det = PhaseDetector(q_feat, q_conf, q_phase)
+    assist = TraderAssist(q_phase, q_conf, q_adv)
+    dash = Dashboard(q_conf, q_phase, q_adv)
+
+    await ingestor.start()
+
+    await asyncio.gather(
+        feat_eng.run(),
+        conf_eng.run(),
+        phase_det.run(),
+        assist.run(),
+        dash.run(),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- restore the full NG trend confidence dashboard implementation
- keep live dashboard prototype unchanged
- add unified NG edge dashboard implementation

## Testing
- `python -m py_compile live_dash.py ng_trend_dashboard.py`
- `python -m py_compile cme_dashboard_v1.py`


------
https://chatgpt.com/codex/tasks/task_e_685695bc75388332a291f76b14c51297